### PR TITLE
feat: output config to stats.csv

### DIFF
--- a/simple/run.sh
+++ b/simple/run.sh
@@ -2,6 +2,8 @@
 
 CSV=`dirname $0`/../stats.csv
 REPORT=`dirname $0`/../report.lua
+EGG=egg@`sed -n 's/[ ]*\"version\": \"\([^,]*\)\"[,]*/\1/p' node_modules/egg/package.json`
+NODE=node@`node -v`
 
 echo
 EGG_SERVER_ENV=prod node $NODE_FLAGS `dirname $0`/dispatch.js $1 &
@@ -16,10 +18,16 @@ curl 'http://127.0.0.1:7001/aa'
 
 test `tail -c 1 $CSV` && printf "\n" >> $CSV
 
+function print_head {
+  NAME=$1
+  printf "\"$EGG, $NODE\"," >> $CSV
+  printf "\"$NAME\"," >> $CSV
+}
+
 echo ""
 echo "------- koa1 hello -------"
 echo ""
-printf "\"koa1 hello\"," >> $CSV
+print_head "koa1 hello"
 wrk 'http://127.0.0.1:7002/' \
   -d 10 \
   -c 50 \
@@ -29,7 +37,7 @@ wrk 'http://127.0.0.1:7002/' \
 echo ""
 echo "------- koa2 hello -------"
 echo ""
-printf "\"koa2 hello\"," >> $CSV
+print_head "koa2 hello"
 wrk 'http://127.0.0.1:7004/' \
   -d 10 \
   -c 50 \
@@ -40,7 +48,7 @@ sleep 3
 echo ""
 echo "------- toa hello -------"
 echo ""
-printf "\"toa hello\"," >> $CSV
+print_head "toa hello"
 wrk 'http://127.0.0.1:7003/' \
   -d 10 \
   -c 50 \
@@ -51,7 +59,7 @@ sleep 3
 echo ""
 echo "------- egg hello -------"
 echo ""
-printf "\"egg hello\"," >> $CSV
+print_head "egg hello"
 wrk 'http://127.0.0.1:7001/' \
   -d 10 \
   -c 50 \
@@ -62,7 +70,7 @@ sleep 3
 echo ""
 echo "------- egg hello (Async Await) -------"
 echo ""
-printf "\"egg hello (Async Await)\"," >> $CSV
+print_head "egg hello aa"
 wrk 'http://127.0.0.1:7001/aa' \
   -d 10 \
   -c 50 \

--- a/simple_passport/run.sh
+++ b/simple_passport/run.sh
@@ -2,10 +2,18 @@
 
 CSV=`dirname $0`/../stats.csv
 REPORT=`dirname $0`/../report.lua
+EGG=egg@`sed -n 's/[ ]*\"version\": \"\([^,]*\)\"[,]*/\1/p' node_modules/egg/package.json`
+NODE=node@`node -v`
 
 echo
 EGG_SERVER_ENV=prod node $NODE_FLAGS `dirname $0`/dispatch.js $1 &
 pid=$!
+
+function print_head {
+  NAME=$1
+  printf "\"$EGG, $NODE\"," >> $CSV
+  printf "\"$NAME\"," >> $CSV
+}
 
 sleep 6
 curl 'http://127.0.0.1:7001/'
@@ -17,7 +25,7 @@ sleep 3
 echo ""
 echo "------- egg passport -------"
 echo ""
-printf "\"egg passport\"," >> $CSV
+print_head "egg passport"
 wrk 'http://127.0.0.1:7001/' \
   -d 10 \
   -c 50 \
@@ -28,7 +36,7 @@ sleep 3
 echo ""
 echo "------- egg passport (Async Await) -------"
 echo ""
-printf "\"egg passport (Async Await)\"," >> $CSV
+print_head "egg passport aa"
 wrk 'http://127.0.0.1:7001/aa' \
   -d 10 \
   -c 50 \

--- a/simple_view/run.sh
+++ b/simple_view/run.sh
@@ -2,6 +2,8 @@
 
 CSV=`dirname $0`/../stats.csv
 REPORT=`dirname $0`/../report.lua
+EGG=egg@`sed -n 's/[ ]*\"version\": \"\([^,]*\)\"[,]*/\1/p' node_modules/egg/package.json`
+NODE=node@`node -v`
 
 echo
 EGG_SERVER_ENV=prod node $NODE_FLAGS `dirname $0`/dispatch.js $1 &
@@ -18,10 +20,16 @@ curl 'http://127.0.0.1:7001/ejs-aa' -s | grep 'title'
 
 test `tail -c 1 $CSV` && printf "\n" >> $CSV
 
+function print_head {
+  NAME=$1
+  printf "\"$EGG, $NODE\"," >> $CSV
+  printf "\"$NAME\"," >> $CSV
+}
+
 echo ""
 echo "------- koa1 view -------"
 echo ""
-printf "\"koa1 view\"," >> $CSV
+print_head "koa1 view"
 wrk 'http://127.0.0.1:7002/' \
   -d 10 \
   -c 50 \
@@ -31,7 +39,7 @@ wrk 'http://127.0.0.1:7002/' \
 echo ""
 echo "------- koa2 view -------"
 echo ""
-printf "\"koa2 view\"," >> $CSV
+print_head "koa2 view"
 wrk 'http://127.0.0.1:7004/' \
   -d 10 \
   -c 50 \
@@ -42,7 +50,7 @@ sleep 3
 echo ""
 echo "------- toa view -------"
 echo ""
-printf "\"toa view\"," >> $CSV
+print_head "toa view"
 wrk 'http://127.0.0.1:7003/' \
   -d 10 \
   -c 50 \
@@ -53,7 +61,7 @@ sleep 3
 echo ""
 echo "------- egg nunjucks view -------"
 echo ""
-printf "\"egg nunjucks view\"," >> $CSV
+print_head "egg nunjucks view"
 wrk 'http://127.0.0.1:7001/nunjucks' \
   -d 10 \
   -c 50 \
@@ -64,7 +72,7 @@ sleep 3
 echo ""
 echo "------- egg ejs view -------"
 echo ""
-printf "\"egg ejs view\"," >> $CSV
+print_head "egg ejs view"
 wrk 'http://127.0.0.1:7001/ejs' \
   -d 10 \
   -c 50 \
@@ -75,7 +83,7 @@ sleep 3
 echo ""
 echo "------- egg nunjucks view (Async Await) -------"
 echo ""
-printf "\"egg nunjucks view (Async Await)\"," >> $CSV
+print_head "egg nunjucks view aa"
 wrk 'http://127.0.0.1:7001/nunjucks-aa' \
   -d 10 \
   -c 50 \
@@ -86,7 +94,7 @@ sleep 3
 echo ""
 echo "------- egg ejs view (Async Await) -------"
 echo ""
-printf "\"egg ejs view (Async Await)\"," >> $CSV
+print_head "egg ejs view aa"
 wrk 'http://127.0.0.1:7001/ejs-aa' \
   -d 10 \
   -c 50 \

--- a/stats-header.csv
+++ b/stats-header.csv
@@ -1,1 +1,1 @@
-name,latency_min,latency_max,latency_mean,latency_stdev,duration,requests,bytes,req_per_sec,byte_per_sec
+config,name,latency_min,latency_max,latency_mean,latency_stdev,duration,requests,bytes,req_per_sec,byte_per_sec


### PR DESCRIPTION
Output the version of egg and the version of node to stats.csv so we can compare the performance impact between different versions. With commands like:

```
nvm use v8.0.0-nightly20170411b8f416023d
npm test
mv stats.csv nightly.csv
nvm use v8.0.0-test201704119b43f9c487
npm test
tail -n +2 nightly.csv >> stats.csv
```

We will be able to produce plots like this:

<img width="1205" alt="screen shot 2017-04-13 at 11 04 57 am" src="https://cloud.githubusercontent.com/assets/4299420/24988514/0804c8e8-2039-11e7-972e-ef761dd85ca8.png">
